### PR TITLE
Implement basic user registration API

### DIFF
--- a/back/src/main/java/com/stock/bion/back/config/SecurityConfig.java
+++ b/back/src/main/java/com/stock/bion/back/config/SecurityConfig.java
@@ -1,0 +1,17 @@
+package com.stock.bion.back.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.web.SecurityFilterChain;
+
+@Configuration
+public class SecurityConfig {
+
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+        http.csrf(csrf -> csrf.disable())
+            .authorizeHttpRequests(auth -> auth.anyRequest().permitAll());
+        return http.build();
+    }
+}

--- a/back/src/main/java/com/stock/bion/back/user/User.java
+++ b/back/src/main/java/com/stock/bion/back/user/User.java
@@ -1,0 +1,23 @@
+package com.stock.bion.back.user;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Entity
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class User {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    private String username;
+    private String password;
+}

--- a/back/src/main/java/com/stock/bion/back/user/UserController.java
+++ b/back/src/main/java/com/stock/bion/back/user/UserController.java
@@ -1,0 +1,26 @@
+package com.stock.bion.back.user;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/users")
+@RequiredArgsConstructor
+public class UserController {
+
+    private final UserRepository userRepository;
+
+    @PostMapping("/register")
+    public ResponseEntity<User> register(@RequestBody UserRegistrationRequest request) {
+        User user = new User();
+        user.setUsername(request.username());
+        user.setPassword(request.password());
+        User saved = userRepository.save(user);
+        saved.setPassword(null); // do not expose password
+        return ResponseEntity.ok(saved);
+    }
+}

--- a/back/src/main/java/com/stock/bion/back/user/UserRegistrationRequest.java
+++ b/back/src/main/java/com/stock/bion/back/user/UserRegistrationRequest.java
@@ -1,0 +1,4 @@
+package com.stock.bion.back.user;
+
+public record UserRegistrationRequest(String username, String password) {
+}

--- a/back/src/main/java/com/stock/bion/back/user/UserRepository.java
+++ b/back/src/main/java/com/stock/bion/back/user/UserRepository.java
@@ -1,0 +1,6 @@
+package com.stock.bion.back.user;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface UserRepository extends JpaRepository<User, Long> {
+}

--- a/back/src/main/resources/application.properties
+++ b/back/src/main/resources/application.properties
@@ -1,1 +1,4 @@
 spring.application.name=back
+spring.datasource.url=jdbc:h2:mem:testdb
+spring.jpa.hibernate.ddl-auto=update
+spring.h2.console.enabled=true

--- a/back/src/test/java/com/stock/bion/back/user/UserControllerTests.java
+++ b/back/src/test/java/com/stock/bion/back/user/UserControllerTests.java
@@ -1,0 +1,35 @@
+package com.stock.bion.back.user;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+class UserControllerTests {
+
+    @Autowired
+    MockMvc mockMvc;
+    @Autowired
+    ObjectMapper objectMapper;
+
+    @Test
+    void registerUserReturnsCreatedUser() throws Exception {
+        UserRegistrationRequest request = new UserRegistrationRequest("user1", "pass1");
+        mockMvc.perform(post("/api/users/register")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.id").isNumber())
+                .andExpect(jsonPath("$.username").value("user1"))
+                .andExpect(jsonPath("$.password").doesNotExist());
+    }
+}


### PR DESCRIPTION
## Summary
- implement `User` entity, repository, and controller
- allow open access via `SecurityConfig`
- set up in-memory H2 datasource
- add integration test for registration endpoint

## Testing
- `gradle test` *(fails: Plugin not found due to offline environment)*

------
https://chatgpt.com/codex/tasks/task_e_685ca5e51bac8323920aa9c4ed994af5