### PR TITLE
Add unique username constraint

### DIFF
--- a/back/src/main/java/com/stock/bion/back/user/User.java
+++ b/back/src/main/java/com/stock/bion/back/user/User.java
@@ -5,6 +5,7 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
+import jakarta.persistence.Column;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -20,6 +21,8 @@ public class User {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
+
+    @Column(unique = true)
     private String username;
     private String password;
 }

--- a/back/src/main/java/com/stock/bion/back/user/UserController.java
+++ b/back/src/main/java/com/stock/bion/back/user/UserController.java
@@ -1,6 +1,7 @@
 package com.stock.bion.back.user;
 
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -16,7 +17,11 @@ public class UserController {
     private final org.springframework.security.crypto.password.PasswordEncoder passwordEncoder;
 
     @PostMapping("/register")
-    public ResponseEntity<User> register(@RequestBody UserRegistrationRequest request) {
+    public ResponseEntity<?> register(@RequestBody UserRegistrationRequest request) {
+        if (userRepository.findByUsername(request.username()) != null) {
+            return ResponseEntity.status(HttpStatus.CONFLICT).build();
+        }
+
         User user = new User();
         user.setUsername(request.username());
         user.setPassword(passwordEncoder.encode(request.password()));

--- a/back/src/test/java/com/stock/bion/back/user/UserControllerTests.java
+++ b/back/src/test/java/com/stock/bion/back/user/UserControllerTests.java
@@ -48,4 +48,18 @@ class UserControllerTests {
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.token").isString());
     }
+
+    @Test
+    void duplicateUsernameReturnsError() throws Exception {
+        UserRegistrationRequest request = new UserRegistrationRequest("dupuser", "pass1");
+        mockMvc.perform(post("/api/users/register")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isOk());
+
+        mockMvc.perform(post("/api/users/register")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isConflict());
+    }
 }


### PR DESCRIPTION
## Summary
- enforce unique usernames with `@Column(unique = true)`
- return 409 Conflict when registering an existing username
- test duplicate username registration

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_685cb3d0a3648323b0dc9fcb376073c1