### PR TITLE
Add email and phone to registration

### DIFF
--- a/back/src/main/java/com/stock/bion/back/user/User.java
+++ b/back/src/main/java/com/stock/bion/back/user/User.java
@@ -25,4 +25,9 @@ public class User {
     @Column(unique = true)
     private String username;
     private String password;
+
+    @Column(unique = true)
+    private String email;
+
+    private String phone;
 }

--- a/back/src/main/java/com/stock/bion/back/user/UserController.java
+++ b/back/src/main/java/com/stock/bion/back/user/UserController.java
@@ -7,6 +7,7 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+import java.util.Map;
 
 @RestController
 @RequestMapping("/api/users")
@@ -18,6 +19,10 @@ public class UserController {
 
     @PostMapping("/register")
     public ResponseEntity<?> register(@RequestBody UserRegistrationRequest request) {
+        if (!request.password().equals(request.confirmPassword())) {
+            return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+                    .body(Map.of("message", "Passwords do not match"));
+        }
         if (userRepository.findByUsername(request.username()) != null) {
             return ResponseEntity.status(HttpStatus.CONFLICT).build();
         }
@@ -25,6 +30,8 @@ public class UserController {
         User user = new User();
         user.setUsername(request.username());
         user.setPassword(passwordEncoder.encode(request.password()));
+        user.setEmail(request.email());
+        user.setPhone(request.phone());
         User saved = userRepository.save(user);
         saved.setPassword(null); // do not expose password
         return ResponseEntity.ok(saved);

--- a/back/src/main/java/com/stock/bion/back/user/UserRegistrationRequest.java
+++ b/back/src/main/java/com/stock/bion/back/user/UserRegistrationRequest.java
@@ -1,4 +1,9 @@
 package com.stock.bion.back.user;
 
-public record UserRegistrationRequest(String username, String password) {
+public record UserRegistrationRequest(
+        String username,
+        String password,
+        String confirmPassword,
+        String email,
+        String phone) {
 }

--- a/back/src/test/java/com/stock/bion/back/user/UserControllerTests.java
+++ b/back/src/test/java/com/stock/bion/back/user/UserControllerTests.java
@@ -23,19 +23,31 @@ class UserControllerTests {
 
     @Test
     void registerUserReturnsCreatedUser() throws Exception {
-        UserRegistrationRequest request = new UserRegistrationRequest("user1", "pass1");
+        UserRegistrationRequest request = new UserRegistrationRequest(
+                "user1",
+                "pass1",
+                "pass1",
+                "user1@example.com",
+                "01000000001");
         mockMvc.perform(post("/api/users/register")
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(objectMapper.writeValueAsString(request)))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.id").isNumber())
                 .andExpect(jsonPath("$.username").value("user1"))
-                .andExpect(jsonPath("$.password").doesNotExist());
+                .andExpect(jsonPath("$.password").doesNotExist())
+                .andExpect(jsonPath("$.email").value("user1@example.com"))
+                .andExpect(jsonPath("$.phone").value("01000000001"));
     }
 
     @Test
     void loginReturnsToken() throws Exception {
-        UserRegistrationRequest request = new UserRegistrationRequest("loginuser", "pass1");
+        UserRegistrationRequest request = new UserRegistrationRequest(
+                "loginuser",
+                "pass1",
+                "pass1",
+                "loginuser@example.com",
+                "01000000002");
         mockMvc.perform(post("/api/users/register")
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(objectMapper.writeValueAsString(request)))
@@ -51,7 +63,12 @@ class UserControllerTests {
 
     @Test
     void duplicateUsernameReturnsError() throws Exception {
-        UserRegistrationRequest request = new UserRegistrationRequest("dupuser", "pass1");
+        UserRegistrationRequest request = new UserRegistrationRequest(
+                "dupuser",
+                "pass1",
+                "pass1",
+                "dupuser@example.com",
+                "01000000003");
         mockMvc.perform(post("/api/users/register")
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(objectMapper.writeValueAsString(request)))

--- a/front/src/RegisterForm.tsx
+++ b/front/src/RegisterForm.tsx
@@ -3,21 +3,31 @@ import { type FormEvent, useState } from 'react'
 function RegisterForm() {
   const [username, setUsername] = useState('')
   const [password, setPassword] = useState('')
+  const [confirmPassword, setConfirmPassword] = useState('')
+  const [email, setEmail] = useState('')
+  const [phone, setPhone] = useState('')
   const [message, setMessage] = useState('')
 
   const handleSubmit = async (e: FormEvent) => {
     e.preventDefault()
+    if (password !== confirmPassword) {
+      setMessage('Passwords do not match')
+      return
+    }
     try {
       const res = await fetch(`${import.meta.env.VITE_API_BASE_URL || ''}/api/users/register`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ username, password }),
+        body: JSON.stringify({ username, password, confirmPassword, email, phone }),
       })
 
       if (res.ok) {
         setMessage('Registered successfully')
         setUsername('')
         setPassword('')
+        setConfirmPassword('')
+        setEmail('')
+        setPhone('')
       } else {
         let errorMsg = 'Registration failed'
         try {
@@ -49,6 +59,27 @@ function RegisterForm() {
         value={password}
         onChange={(e) => setPassword(e.target.value)}
         placeholder="Password"
+        className="border rounded p-2"
+      />
+      <input
+        type="password"
+        value={confirmPassword}
+        onChange={(e) => setConfirmPassword(e.target.value)}
+        placeholder="Confirm Password"
+        className="border rounded p-2"
+      />
+      <input
+        type="email"
+        value={email}
+        onChange={(e) => setEmail(e.target.value)}
+        placeholder="Email"
+        className="border rounded p-2"
+      />
+      <input
+        type="tel"
+        value={phone}
+        onChange={(e) => setPhone(e.target.value)}
+        placeholder="Phone"
         className="border rounded p-2"
       />
       <button type="submit" className="bg-blue-500 text-white rounded p-2">


### PR DESCRIPTION
## Summary
- extend registration form with email, phone, and password confirmation
- save email and phone on the backend and validate password confirmation
- update user entity, request DTO, controller, and related tests

## Testing
- `./gradlew test` *(fails: Unable to download gradle wrapper)*
- `npm run lint` *(fails: missing packages @eslint/js)*

------
https://chatgpt.com/codex/tasks/task_e_685cc3d915d48323b20e19d12d459468