### PR TITLE
Improve front-end design

### DIFF
--- a/front/index.html
+++ b/front/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Vite + React + TS</title>
+    <title>Stock App</title>
   </head>
   <body>
     <div id="root"></div>

--- a/front/src/LoginForm.tsx
+++ b/front/src/LoginForm.tsx
@@ -1,6 +1,8 @@
 import { type FormEvent, useState } from 'react'
+import { useNavigate } from 'react-router-dom'
 
 function LoginForm() {
+  const navigate = useNavigate()
   const [username, setUsername] = useState('')
   const [password, setPassword] = useState('')
   const [message, setMessage] = useState('')
@@ -18,9 +20,9 @@ function LoginForm() {
         const data = await res.json()
         if (data && typeof data.token === 'string') {
           localStorage.setItem('token', data.token)
-          setMessage('Login successful')
           setUsername('')
           setPassword('')
+          navigate('/')
         } else {
           setMessage('Invalid response from server')
         }
@@ -35,24 +37,22 @@ function LoginForm() {
   }
 
   return (
-    <form onSubmit={handleSubmit} className="flex flex-col gap-2 max-w-xs">
+    <form onSubmit={handleSubmit} className="flex flex-col gap-3">
       <input
         type="text"
         value={username}
         onChange={(e) => setUsername(e.target.value)}
         placeholder="Username"
-        className="border rounded p-2"
+        className="form-field"
       />
       <input
         type="password"
         value={password}
         onChange={(e) => setPassword(e.target.value)}
         placeholder="Password"
-        className="border rounded p-2"
+        className="form-field"
       />
-      <button type="submit" className="bg-green-500 text-white rounded p-2">
-        Login
-      </button>
+      <button type="submit" className="button-primary">Login</button>
       {message && <p>{message}</p>}
     </form>
   )

--- a/front/src/RegisterForm.tsx
+++ b/front/src/RegisterForm.tsx
@@ -1,6 +1,8 @@
 import { type FormEvent, useState } from 'react'
+import { useNavigate } from 'react-router-dom'
 
 function RegisterForm() {
+  const navigate = useNavigate()
   const [username, setUsername] = useState('')
   const [password, setPassword] = useState('')
   const [confirmPassword, setConfirmPassword] = useState('')
@@ -26,12 +28,12 @@ function RegisterForm() {
       })
 
       if (res.ok) {
-        setMessage('Registered successfully')
         setUsername('')
         setPassword('')
         setConfirmPassword('')
         setEmail('')
         setPhone('')
+        navigate('/login')
       } else {
         let errorMsg = 'Registration failed'
         try {
@@ -50,13 +52,13 @@ function RegisterForm() {
   }
 
   return (
-    <form onSubmit={handleSubmit} className="flex flex-col gap-2 max-w-xs">
+    <form onSubmit={handleSubmit} className="flex flex-col gap-3">
       <input
         type="text"
         value={username}
         onChange={(e) => setUsername(e.target.value)}
         placeholder="Username"
-        className="border rounded p-2"
+        className="form-field"
         required
       />
       <input
@@ -64,7 +66,7 @@ function RegisterForm() {
         value={password}
         onChange={(e) => setPassword(e.target.value)}
         placeholder="Password"
-        className="border rounded p-2"
+        className="form-field"
         required
       />
       <input
@@ -72,7 +74,7 @@ function RegisterForm() {
         value={confirmPassword}
         onChange={(e) => setConfirmPassword(e.target.value)}
         placeholder="Confirm Password"
-        className="border rounded p-2"
+        className="form-field"
         required
       />
       <input
@@ -80,7 +82,7 @@ function RegisterForm() {
         value={email}
         onChange={(e) => setEmail(e.target.value)}
         placeholder="Email"
-        className="border rounded p-2"
+        className="form-field"
         required
       />
       <input
@@ -88,12 +90,10 @@ function RegisterForm() {
         value={phone}
         onChange={(e) => setPhone(e.target.value)}
         placeholder="Phone"
-        className="border rounded p-2"
+        className="form-field"
         required
       />
-      <button type="submit" className="bg-blue-500 text-white rounded p-2">
-        Register
-      </button>
+      <button type="submit" className="button-primary">Register</button>
       {message && <p>{message}</p>}
     </form>
   )

--- a/front/src/index.css
+++ b/front/src/index.css
@@ -1,3 +1,23 @@
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
+
+body {
+  @apply bg-gray-100 text-gray-900;
+}
+
+.main-container {
+  @apply max-w-md mx-auto mt-10 p-6 bg-white rounded shadow;
+}
+
+.form-field {
+  @apply border rounded p-2 w-full;
+}
+
+.button-primary {
+  @apply bg-blue-600 text-white rounded p-2 hover:bg-blue-700;
+}
+
+.link {
+  @apply text-blue-500 hover:underline;
+}

--- a/front/src/pages/HomePage.tsx
+++ b/front/src/pages/HomePage.tsx
@@ -2,11 +2,15 @@ import { Link } from 'react-router-dom'
 
 function HomePage() {
   return (
-    <div className="p-4">
-      <h1 className="text-2xl mb-4">Welcome</h1>
-      <div className="flex gap-4">
-        <Link to="/login" className="text-blue-500 underline">Login</Link>
-        <Link to="/register" className="text-blue-500 underline">Register</Link>
+    <div className="main-container text-center">
+      <h1 className="text-3xl font-semibold mb-6">Welcome</h1>
+      <div className="flex justify-center gap-6">
+        <Link to="/login" className="link">
+          Login
+        </Link>
+        <Link to="/register" className="link">
+          Register
+        </Link>
       </div>
     </div>
   )

--- a/front/src/pages/LoginPage.tsx
+++ b/front/src/pages/LoginPage.tsx
@@ -1,10 +1,17 @@
 import LoginForm from '../LoginForm'
+import { Link } from 'react-router-dom'
 
 function LoginPage() {
   return (
-    <div className="p-4">
-      <h2 className="text-xl mb-4">Login</h2>
+    <div className="main-container">
+      <h2 className="text-2xl font-medium mb-4 text-center">Login</h2>
       <LoginForm />
+      <p className="mt-4 text-center">
+        Don't have an account?{' '}
+        <Link to="/register" className="link">
+          Register
+        </Link>
+      </p>
     </div>
   )
 }

--- a/front/src/pages/RegisterPage.tsx
+++ b/front/src/pages/RegisterPage.tsx
@@ -1,10 +1,17 @@
 import RegisterForm from '../RegisterForm'
+import { Link } from 'react-router-dom'
 
 function RegisterPage() {
   return (
-    <div className="p-4">
-      <h2 className="text-xl mb-4">Register</h2>
+    <div className="main-container">
+      <h2 className="text-2xl font-medium mb-4 text-center">Register</h2>
       <RegisterForm />
+      <p className="mt-4 text-center">
+        Already have an account?{' '}
+        <Link to="/login" className="link">
+          Login
+        </Link>
+      </p>
     </div>
   )
 }


### PR DESCRIPTION
## Summary
- modernize front-end pages with shared Tailwind styles
- add navigation links between login and register pages
- redirect on successful login and registration
- update default title

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `./gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_685ccacb04bc83238f101b6c997dd813