### PR TITLE
Add stock price API

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,7 @@ alpaca:
 | POST | `/api/v1/trades/execute` | `{ "signalRunId":123 }`                  | 해당 시그널로 주문 실행                |
 | GET  | `/api/v1/review/daily`   | `userId`, `date`                         | 일일 P\&L, 승률, 차트 URL          |
 | GET  | `/api/v1/review/weekly`  | `userId`, `week`                         | 주간 통계 및 파라미터 변화              |
+| GET  | `/api/stocks/{code}`     | -                                        | 현재 주가 조회                        |
 
 모든 엔드포인트는 `Authorization: Bearer <JWT>` 필요 (Spring Security HS256).
 

--- a/back/build.gradle
+++ b/back/build.gradle
@@ -33,6 +33,7 @@ dependencies {
         runtimeOnly 'org.postgresql:postgresql'
         runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
         runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
+        implementation 'org.jsoup:jsoup:1.17.2'
         annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'org.springframework.security:spring-security-test'

--- a/back/src/main/java/com/stock/bion/back/stock/StockController.java
+++ b/back/src/main/java/com/stock/bion/back/stock/StockController.java
@@ -1,0 +1,20 @@
+package com.stock.bion.back.stock;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/stocks")
+@RequiredArgsConstructor
+public class StockController {
+    private final StockService stockService;
+
+    @GetMapping("/{code}")
+    public ResponseEntity<StockInfo> getStock(@PathVariable String code) throws Exception {
+        return ResponseEntity.ok(stockService.fetchStock(code));
+    }
+}

--- a/back/src/main/java/com/stock/bion/back/stock/StockInfo.java
+++ b/back/src/main/java/com/stock/bion/back/stock/StockInfo.java
@@ -1,0 +1,4 @@
+package com.stock.bion.back.stock;
+
+public record StockInfo(String code, long price) {
+}

--- a/back/src/main/java/com/stock/bion/back/stock/StockService.java
+++ b/back/src/main/java/com/stock/bion/back/stock/StockService.java
@@ -1,0 +1,16 @@
+package com.stock.bion.back.stock;
+
+import org.jsoup.Jsoup;
+import org.jsoup.nodes.Document;
+import org.springframework.stereotype.Service;
+
+@Service
+public class StockService {
+    public StockInfo fetchStock(String code) throws Exception {
+        String url = "https://finance.naver.com/item/main.naver?code=" + code;
+        Document doc = Jsoup.connect(url).get();
+        String text = doc.selectFirst("p.no_today span.blind").text();
+        long price = Long.parseLong(text.replace(",", ""));
+        return new StockInfo(code, price);
+    }
+}

--- a/back/src/test/java/com/stock/bion/back/stock/StockControllerTests.java
+++ b/back/src/test/java/com/stock/bion/back/stock/StockControllerTests.java
@@ -1,0 +1,41 @@
+package com.stock.bion.back.stock;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+class StockControllerTests {
+
+    @Autowired
+    MockMvc mockMvc;
+
+    @Autowired
+    ObjectMapper objectMapper;
+
+    @MockBean
+    StockService stockService;
+
+    @Test
+    void getStockReturnsInfo() throws Exception {
+        given(stockService.fetchStock("005930"))
+                .willReturn(new StockInfo("005930", 123456L));
+
+        mockMvc.perform(get("/api/stocks/005930")
+                .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.code").value("005930"))
+                .andExpect(jsonPath("$.price").value(123456));
+    }
+}


### PR DESCRIPTION
## Summary
- add Jsoup dependency
- implement `StockInfo`, `StockService` and controller for `/api/stocks/{code}`
- document new endpoint in README
- test controller using `@MockBean`

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_685eac6987b08323ae1e32f46189fd37