### PR TITLE
Add stock price page

### DIFF
--- a/front/README.md
+++ b/front/README.md
@@ -1,5 +1,14 @@
 # React + TypeScript + Vite
 
+This app now includes a simple stock price page. After starting the dev server you can
+click **Stock** on the home page (or open `/stock/005930`) to fetch data from
+`/api/stocks/{code}`.
+
+```
+npm install
+npm run dev
+```
+
 This template provides a minimal setup to get React working in Vite with HMR and some ESLint rules.
 
 Currently, two official plugins are available:

--- a/front/src/App.tsx
+++ b/front/src/App.tsx
@@ -2,6 +2,7 @@ import { Routes, Route } from 'react-router-dom'
 import HomePage from './pages/HomePage'
 import LoginPage from './pages/LoginPage'
 import RegisterPage from './pages/RegisterPage'
+import StockPage from './pages/StockPage'
 
 function App() {
   return (
@@ -9,6 +10,7 @@ function App() {
       <Route path="/" element={<HomePage />} />
       <Route path="/login" element={<LoginPage />} />
       <Route path="/register" element={<RegisterPage />} />
+      <Route path="/stock/:code" element={<StockPage />} />
     </Routes>
   )
 }

--- a/front/src/pages/HomePage.tsx
+++ b/front/src/pages/HomePage.tsx
@@ -11,6 +11,9 @@ function HomePage() {
         <Link to="/register" className="link">
           Register
         </Link>
+        <Link to="/stock/005930" className="link">
+          Stock
+        </Link>
       </div>
     </div>
   )

--- a/front/src/pages/StockPage.tsx
+++ b/front/src/pages/StockPage.tsx
@@ -1,0 +1,49 @@
+import { useEffect, useState } from 'react'
+import { useParams } from 'react-router-dom'
+
+interface StockInfo {
+  code: string
+  price: number
+}
+
+function StockPage() {
+  const { code } = useParams<{ code: string }>()
+  const [data, setData] = useState<StockInfo | null>(null)
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState('')
+
+  useEffect(() => {
+    const fetchStock = async () => {
+      try {
+        const res = await fetch(`${import.meta.env.VITE_API_BASE_URL || ''}/api/stocks/${code}`, {
+          headers: {
+            Authorization: `Bearer ${localStorage.getItem('token') || ''}`,
+          },
+        })
+        if (!res.ok) throw new Error('Request failed')
+        const json = await res.json()
+        setData(json)
+      } catch {
+        setError('Failed to load stock data')
+      } finally {
+        setLoading(false)
+      }
+    }
+    fetchStock()
+  }, [code])
+
+  return (
+    <div className="main-container text-center">
+      {loading && <p>Loading...</p>}
+      {error && <p>{error}</p>}
+      {data && (
+        <>
+          <h2 className="text-2xl font-medium mb-4">{data.code}</h2>
+          <p className="text-xl">Price: {data.price}</p>
+        </>
+      )}
+    </div>
+  )
+}
+
+export default StockPage


### PR DESCRIPTION
## Summary
- create `StockPage` for fetching and displaying stock prices
- link to the stock page from `HomePage`
- wire the new route in `App`
- document how to use the new page in `front/README.md`

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `./gradlew test` *(fails: unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_685ead6b6500832391cb74a922bb1a2a