### PR TITLE
Add React form tests with Vitest

### DIFF
--- a/front/README.md
+++ b/front/README.md
@@ -7,7 +7,10 @@ click **Stock** on the home page (or open `/stock/005930`) to fetch data from
 ```
 npm install
 npm run dev
+npm test
 ```
+
+Run `npm test` to execute Vitest unit tests for the forms.
 
 This template provides a minimal setup to get React working in Vite with HMR and some ESLint rules.
 

--- a/front/package.json
+++ b/front/package.json
@@ -7,7 +7,8 @@
     "dev": "vite",
     "build": "tsc -b && vite build",
     "lint": "eslint .",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "vitest"
   },
   "dependencies": {
     "react": "^19.1.0",
@@ -29,6 +30,10 @@
     "tailwindcss": "^3.4.0",
     "typescript": "~5.8.3",
     "typescript-eslint": "^8.34.1",
-    "vite": "^7.0.0"
+    "vite": "^7.0.0",
+    "@testing-library/jest-dom": "^6.1.5",
+    "@testing-library/react": "^15.2.1",
+    "jsdom": "^24.0.0",
+    "vitest": "^1.4.0"
   }
 }

--- a/front/src/LoginForm.test.tsx
+++ b/front/src/LoginForm.test.tsx
@@ -1,0 +1,20 @@
+import { render, screen, fireEvent } from '@testing-library/react'
+import LoginForm from './LoginForm'
+import { vi } from 'vitest'
+
+vi.mock('react-router-dom', () => ({
+  useNavigate: () => vi.fn(),
+}))
+
+describe('LoginForm', () => {
+  it('shows error message for invalid credentials', async () => {
+    global.fetch = vi.fn().mockResolvedValue({ ok: false, status: 401 }) as any
+
+    render(<LoginForm />)
+    fireEvent.change(screen.getByPlaceholderText('Username'), { target: { value: 'u' } })
+    fireEvent.change(screen.getByPlaceholderText('Password'), { target: { value: 'p' } })
+    fireEvent.submit(screen.getByRole('button', { name: /login/i }))
+
+    expect(await screen.findByText('Invalid credentials')).toBeInTheDocument()
+  })
+})

--- a/front/src/RegisterForm.test.tsx
+++ b/front/src/RegisterForm.test.tsx
@@ -1,0 +1,30 @@
+import { render, screen, fireEvent } from '@testing-library/react'
+import RegisterForm from './RegisterForm'
+import { vi } from 'vitest'
+
+vi.mock('react-router-dom', () => ({
+  useNavigate: () => vi.fn(),
+}))
+
+describe('RegisterForm', () => {
+  it('requires all fields', async () => {
+    render(<RegisterForm />)
+    fireEvent.submit(screen.getByRole('button', { name: /register/i }))
+
+    expect(await screen.findByText('All fields are required')).toBeInTheDocument()
+  })
+
+  it('validates password confirmation', async () => {
+    render(<RegisterForm />)
+
+    fireEvent.change(screen.getByPlaceholderText('Username'), { target: { value: 'u' } })
+    fireEvent.change(screen.getByPlaceholderText('Password'), { target: { value: 'p1' } })
+    fireEvent.change(screen.getByPlaceholderText('Confirm Password'), { target: { value: 'p2' } })
+    fireEvent.change(screen.getByPlaceholderText('Email'), { target: { value: 'test@example.com' } })
+    fireEvent.change(screen.getByPlaceholderText('Phone'), { target: { value: '123' } })
+
+    fireEvent.submit(screen.getByRole('button', { name: /register/i }))
+
+    expect(await screen.findByText('Passwords do not match')).toBeInTheDocument()
+  })
+})

--- a/front/src/setupTests.ts
+++ b/front/src/setupTests.ts
@@ -1,0 +1,1 @@
+import '@testing-library/jest-dom'

--- a/front/tsconfig.vitest.json
+++ b/front/tsconfig.vitest.json
@@ -1,0 +1,6 @@
+{
+  "extends": "./tsconfig.node.json",
+  "compilerOptions": {
+    "types": ["vitest/globals"]
+  }
+}

--- a/front/vite.config.ts
+++ b/front/vite.config.ts
@@ -12,5 +12,10 @@ export default defineConfig(({ mode }) => {
         '/api': apiBaseUrl,
       },
     },
+    test: {
+      globals: true,
+      environment: 'jsdom',
+      setupFiles: './src/setupTests.ts',
+    },
   }
 })


### PR DESCRIPTION
## Summary
- configure Vitest and testing-library
- add unit tests for LoginForm and RegisterForm
- document how to run tests in the front-end README

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685eaf7e2b7483239198805238c9e3d4