### PR TITLE
Implement price persistence and strategy API

### DIFF
--- a/back/src/main/java/com/stock/bion/back/BackApplication.java
+++ b/back/src/main/java/com/stock/bion/back/BackApplication.java
@@ -2,8 +2,10 @@ package com.stock.bion.back;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
+@EnableScheduling
 public class BackApplication {
 
 	public static void main(String[] args) {

--- a/back/src/main/java/com/stock/bion/back/calculate/CalculateController.java
+++ b/back/src/main/java/com/stock/bion/back/calculate/CalculateController.java
@@ -39,13 +39,13 @@ public class CalculateController {
 		return ResponseEntity.ok(momentumIncreasingService.getByMomentumIncreasing(DataService.TimeFrame.LONG_TERM));
 	}
 
-	@GetMapping("strategy/momentum/middle")
-	public ResponseEntity<List<Stock>> momentumStrategyMiddleTerm() {
-		return ResponseEntity.ok(momentumIncreasingService.getByMomentumIncreasing(DataService.TimeFrame.LONG_TERM));
-	}
+        @GetMapping("strategy/momentum/middle")
+        public ResponseEntity<List<Stock>> momentumStrategyMiddleTerm() {
+                return ResponseEntity.ok(momentumIncreasingService.getByMomentumIncreasing(DataService.TimeFrame.MEDIUM_TERM));
+        }
 
-	@GetMapping("strategy/momentum/short")
-	public ResponseEntity<List<Stock>> momentumStrategyShortTerm() {
-		return ResponseEntity.ok(momentumIncreasingService.getByMomentumIncreasing(DataService.TimeFrame.LONG_TERM));
-	}
+        @GetMapping("strategy/momentum/short")
+        public ResponseEntity<List<Stock>> momentumStrategyShortTerm() {
+                return ResponseEntity.ok(momentumIncreasingService.getByMomentumIncreasing(DataService.TimeFrame.SHORT_TERM));
+        }
 }

--- a/back/src/main/java/com/stock/bion/back/calculate/MomentumIncreasingService.java
+++ b/back/src/main/java/com/stock/bion/back/calculate/MomentumIncreasingService.java
@@ -32,7 +32,7 @@ public class MomentumIncreasingService {
 		return isMomentumIncreasing(prices, alpha, beta);
 	}
 
-	private boolean isMomentumIncreasing(List<Price> prices, double alpha, double beta) {
+        public boolean isMomentumIncreasing(List<Price> prices, double alpha, double beta) {
 		List<Double> d1 = computeDailyReturns(prices); // 1차
 		List<Double> d2 = new ArrayList<>();
 		for (int i = 1; i < d1.size(); i++)

--- a/back/src/main/java/com/stock/bion/back/calculate/StrategyApiController.java
+++ b/back/src/main/java/com/stock/bion/back/calculate/StrategyApiController.java
@@ -1,0 +1,85 @@
+package com.stock.bion.back.calculate;
+
+import com.stock.bion.back.data.DataService;
+import com.stock.bion.back.data.PricePersistenceService;
+import com.stock.bion.back.data.Price;
+import com.stock.bion.back.data.Stock;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/strategies")
+public class StrategyApiController {
+    private final PricePersistenceService priceService;
+    private final TrailingStopStrategyService trailingStopStrategyService;
+    private final MomentumIncreasingService momentumIncreasingService;
+
+    public StrategyApiController(PricePersistenceService priceService,
+                                 TrailingStopStrategyService trailingStopStrategyService,
+                                 MomentumIncreasingService momentumIncreasingService) {
+        this.priceService = priceService;
+        this.trailingStopStrategyService = trailingStopStrategyService;
+        this.momentumIncreasingService = momentumIncreasingService;
+    }
+
+    @GetMapping("/trailing-stop/short")
+    public ResponseEntity<List<Stock>> trailingStopShort() {
+        return ResponseEntity.ok(applyTrailing(DataService.TimeFrame.SHORT_TERM));
+    }
+
+    @GetMapping("/trailing-stop/middle")
+    public ResponseEntity<List<Stock>> trailingStopMiddle() {
+        return ResponseEntity.ok(applyTrailing(DataService.TimeFrame.MEDIUM_TERM));
+    }
+
+    @GetMapping("/trailing-stop/long")
+    public ResponseEntity<List<Stock>> trailingStopLong() {
+        return ResponseEntity.ok(applyTrailing(DataService.TimeFrame.LONG_TERM));
+    }
+
+    @GetMapping("/momentum/short")
+    public ResponseEntity<List<Stock>> momentumShort() {
+        return ResponseEntity.ok(applyMomentum(DataService.TimeFrame.SHORT_TERM));
+    }
+
+    @GetMapping("/momentum/middle")
+    public ResponseEntity<List<Stock>> momentumMiddle() {
+        return ResponseEntity.ok(applyMomentum(DataService.TimeFrame.MEDIUM_TERM));
+    }
+
+    @GetMapping("/momentum/long")
+    public ResponseEntity<List<Stock>> momentumLong() {
+        return ResponseEntity.ok(applyMomentum(DataService.TimeFrame.LONG_TERM));
+    }
+
+    private List<Stock> applyTrailing(DataService.TimeFrame timeframe) {
+        List<Stock> stocks = priceService.getStocks();
+        List<Stock> result = new ArrayList<>();
+        for (Stock stock : stocks) {
+            List<Price> prices = priceService.getPrices(stock.getCode(), timeframe);
+            if (prices.size() < 4) continue;
+            if (trailingStopStrategyService.isNonHerdTrendSignal(prices)) {
+                result.add(stock);
+            }
+        }
+        return result;
+    }
+
+    private List<Stock> applyMomentum(DataService.TimeFrame timeframe) {
+        List<Stock> stocks = priceService.getStocks();
+        List<Stock> result = new ArrayList<>();
+        for (Stock stock : stocks) {
+            List<Price> prices = priceService.getPrices(stock.getCode(), timeframe);
+            if (prices.size() < 4) continue;
+            if (momentumIncreasingService.isMomentumIncreasing(prices, 0.01, 0.0)) {
+                result.add(stock);
+            }
+        }
+        return result;
+    }
+}

--- a/back/src/main/java/com/stock/bion/back/calculate/TrailingStopStrategyService.java
+++ b/back/src/main/java/com/stock/bion/back/calculate/TrailingStopStrategyService.java
@@ -27,7 +27,7 @@ public class TrailingStopStrategyService {
 	 * 핵심 시그널 로직: 1) 오늘 거래량이 전체 기간 중 최고치가 아니어야 합니다. (거래량의 최고점을 피함) 2) 오늘 종가가 이전 최고
 	 * 종가를 돌파해야 합니다. 3) 최근 3일 동안 저가와 고가가 모두 연속 상승해야 합니다.
 	 */
-	private boolean isNonHerdTrendSignal(List<Price> prices) {
+        public boolean isNonHerdTrendSignal(List<Price> prices) {
 		if (prices.size() < 4) {
 			return false;
 		}

--- a/back/src/main/java/com/stock/bion/back/data/PriceEntity.java
+++ b/back/src/main/java/com/stock/bion/back/data/PriceEntity.java
@@ -1,0 +1,26 @@
+package com.stock.bion.back.data;
+
+import jakarta.persistence.*;
+import java.time.LocalDate;
+import lombok.Getter;
+import lombok.Setter;
+
+@Entity
+@Table(name = "prices")
+@Getter
+@Setter
+public class PriceEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String code;
+    private String name;
+    private LocalDate date;
+    private double close;
+    private double diff;
+    private double open;
+    private double high;
+    private double low;
+    private double volume;
+}

--- a/back/src/main/java/com/stock/bion/back/data/PricePersistenceService.java
+++ b/back/src/main/java/com/stock/bion/back/data/PricePersistenceService.java
@@ -1,0 +1,83 @@
+package com.stock.bion.back.data;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.springframework.stereotype.Service;
+
+@Service
+public class PricePersistenceService {
+    private final PriceRepository priceRepository;
+    private final DataService dataService;
+
+    public PricePersistenceService(PriceRepository priceRepository, DataService dataService) {
+        this.priceRepository = priceRepository;
+        this.dataService = dataService;
+    }
+
+    public void fetchAndSavePricesForAllCompanies() {
+        List<Stock> stocks = dataService.getCompanyInfo();
+        for (Stock s : stocks) {
+            fetchAndSavePrices(s);
+        }
+    }
+
+    public void fetchAndSavePrices(Stock stock) {
+        List<Price> prices = dataService.fetchPricesForTimeframe(stock.getCode(), DataService.TimeFrame.SHORT_TERM);
+        for (Price p : prices) {
+            if (!priceRepository.existsByCodeAndDate(stock.getCode(), p.getDate())) {
+                PriceEntity e = toEntity(stock, p);
+                priceRepository.save(e);
+            }
+        }
+    }
+
+    private PriceEntity toEntity(Stock stock, Price p) {
+        PriceEntity e = new PriceEntity();
+        e.setCode(stock.getCode());
+        e.setName(stock.getName());
+        e.setDate(p.getDate());
+        e.setClose(p.getClose());
+        e.setDiff(p.getDiff());
+        e.setOpen(p.getOpen());
+        e.setHigh(p.getHigh());
+        e.setLow(p.getLow());
+        e.setVolume(p.getVolume());
+        return e;
+    }
+
+    private Price toPrice(PriceEntity e) {
+        Price p = new Price();
+        p.setDate(e.getDate());
+        p.setClose(e.getClose());
+        p.setDiff(e.getDiff());
+        p.setOpen(e.getOpen());
+        p.setHigh(e.getHigh());
+        p.setLow(e.getLow());
+        p.setVolume(e.getVolume());
+        return p;
+    }
+
+    public List<Price> getPrices(String code, DataService.TimeFrame timeframe) {
+        List<PriceEntity> list = priceRepository.findByCodeOrderByDateDesc(code);
+        int days = timeframe.getLookbackDays();
+        return list.stream().limit(days).map(this::toPrice).toList();
+    }
+
+    public List<Stock> getStocks() {
+        List<PriceEntity> all = priceRepository.findAll();
+        Map<String, String> map = new HashMap<>();
+        for (PriceEntity e : all) {
+            map.putIfAbsent(e.getCode(), e.getName());
+        }
+        List<Stock> stocks = new ArrayList<>();
+        for (Map.Entry<String, String> entry : map.entrySet()) {
+            Stock s = new Stock();
+            s.setCode(entry.getKey());
+            s.setName(entry.getValue());
+            stocks.add(s);
+        }
+        return stocks;
+    }
+}

--- a/back/src/main/java/com/stock/bion/back/data/PriceRepository.java
+++ b/back/src/main/java/com/stock/bion/back/data/PriceRepository.java
@@ -1,0 +1,14 @@
+package com.stock.bion.back.data;
+
+import java.time.LocalDate;
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+public interface PriceRepository extends JpaRepository<PriceEntity, Long> {
+    List<PriceEntity> findByCodeOrderByDateDesc(String code);
+    boolean existsByCodeAndDate(String code, LocalDate date);
+
+    @Query("select distinct p.code from PriceEntity p")
+    List<String> findDistinctCodes();
+}

--- a/back/src/main/java/com/stock/bion/back/data/PriceScheduler.java
+++ b/back/src/main/java/com/stock/bion/back/data/PriceScheduler.java
@@ -1,0 +1,18 @@
+package com.stock.bion.back.data;
+
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Component
+public class PriceScheduler {
+    private final PricePersistenceService pricePersistenceService;
+
+    public PriceScheduler(PricePersistenceService pricePersistenceService) {
+        this.pricePersistenceService = pricePersistenceService;
+    }
+
+    @Scheduled(cron = "0 0 1 * * *")
+    public void collectDailyPrices() {
+        pricePersistenceService.fetchAndSavePricesForAllCompanies();
+    }
+}

--- a/back/src/test/java/com/stock/bion/back/calculate/StrategyApiControllerTest.java
+++ b/back/src/test/java/com/stock/bion/back/calculate/StrategyApiControllerTest.java
@@ -1,0 +1,61 @@
+package com.stock.bion.back.calculate;
+
+import com.stock.bion.back.data.PriceEntity;
+import com.stock.bion.back.data.PriceRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.time.LocalDate;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@SpringBootTest(properties = "spring.task.scheduling.enabled=false")
+@AutoConfigureMockMvc
+class StrategyApiControllerTest {
+    @Autowired
+    MockMvc mockMvc;
+    @Autowired
+    PriceRepository priceRepository;
+
+    @BeforeEach
+    void setup() {
+        priceRepository.deleteAll();
+        insertSample("AAA", "AAA Corp");
+    }
+
+    private void insertSample(String code, String name) {
+        LocalDate today = LocalDate.now();
+        priceRepository.save(make(code, name, today, 110, 1000));
+        priceRepository.save(make(code, name, today.minusDays(1), 105, 800));
+        priceRepository.save(make(code, name, today.minusDays(2), 100, 900));
+        priceRepository.save(make(code, name, today.minusDays(3), 95, 1100));
+        priceRepository.save(make(code, name, today.minusDays(4), 90, 1200));
+    }
+
+    private PriceEntity make(String code, String name, LocalDate date, double close, double volume) {
+        PriceEntity e = new PriceEntity();
+        e.setCode(code);
+        e.setName(name);
+        e.setDate(date);
+        e.setClose(close);
+        e.setHigh(close);
+        e.setLow(close - 10);
+        e.setOpen(close - 5);
+        e.setVolume(volume);
+        e.setDiff(0);
+        return e;
+    }
+
+    @Test
+    void trailingStopShort_returnsData() throws Exception {
+        mockMvc.perform(get("/api/strategies/trailing-stop/short").accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$[0].code").value("AAA"));
+    }
+}

--- a/back/src/test/java/com/stock/bion/back/data/PricePersistenceServiceTest.java
+++ b/back/src/test/java/com/stock/bion/back/data/PricePersistenceServiceTest.java
@@ -1,0 +1,47 @@
+package com.stock.bion.back.data;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDate;
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class PricePersistenceServiceTest {
+    @Mock
+    private PriceRepository priceRepository;
+    @Mock
+    private DataService dataService;
+    @InjectMocks
+    private PricePersistenceService service;
+
+    private Stock stock;
+    private List<Price> prices;
+
+    @BeforeEach
+    void setup() {
+        stock = new Stock();
+        stock.setCode("AAA");
+        stock.setName("AAA Corp");
+        Price p = new Price();
+        p.setDate(LocalDate.now());
+        prices = List.of(p);
+    }
+
+    @Test
+    void fetchAndSavePrices_saves_when_not_exists() {
+        when(dataService.fetchPricesForTimeframe(eq("AAA"), any())).thenReturn(prices);
+        when(priceRepository.existsByCodeAndDate(eq("AAA"), any())).thenReturn(false);
+
+        service.fetchAndSavePrices(stock);
+
+        verify(priceRepository, times(1)).save(any(PriceEntity.class));
+    }
+}

--- a/front/src/App.tsx
+++ b/front/src/App.tsx
@@ -2,6 +2,7 @@ import { Routes, Route } from 'react-router-dom'
 import HomePage from './pages/HomePage'
 import LoginPage from './pages/LoginPage'
 import RegisterPage from './pages/RegisterPage'
+import StrategiesPage from './pages/StrategiesPage'
 
 function App() {
   return (
@@ -9,6 +10,7 @@ function App() {
       <Route path="/" element={<HomePage />} />
       <Route path="/login" element={<LoginPage />} />
       <Route path="/register" element={<RegisterPage />} />
+      <Route path="/strategies" element={<StrategiesPage />} />
     </Routes>
   )
 }

--- a/front/src/pages/HomePage.tsx
+++ b/front/src/pages/HomePage.tsx
@@ -11,6 +11,9 @@ function HomePage() {
         <Link to="/register" className="link">
           Register
         </Link>
+        <Link to="/strategies" className="link">
+          Strategies
+        </Link>
       </div>
     </div>
   )

--- a/front/src/pages/StrategiesPage.tsx
+++ b/front/src/pages/StrategiesPage.tsx
@@ -1,0 +1,44 @@
+import { useEffect, useState } from 'react'
+
+function StrategiesPage() {
+  const [trailing, setTrailing] = useState<any[]>([])
+  const [momentum, setMomentum] = useState<any[]>([])
+
+  useEffect(() => {
+    fetch(`${import.meta.env.VITE_API_BASE_URL || ''}/api/strategies/trailing-stop/short`)
+      .then((res) => res.json())
+      .then(setTrailing)
+      .catch(() => {})
+
+    fetch(`${import.meta.env.VITE_API_BASE_URL || ''}/api/strategies/momentum/short`)
+      .then((res) => res.json())
+      .then(setMomentum)
+      .catch(() => {})
+  }, [])
+
+  return (
+    <div className="main-container">
+      <h2 className="text-2xl font-medium mb-4 text-center">Strategies</h2>
+      <div>
+        <h3 className="font-semibold">Trailing Stop</h3>
+        <ul>
+          {trailing.map((s) => (
+            <li key={s.code}>
+              {s.name} ({s.code})
+            </li>
+          ))}
+        </ul>
+        <h3 className="font-semibold mt-4">Momentum</h3>
+        <ul>
+          {momentum.map((s) => (
+            <li key={s.code}>
+              {s.name} ({s.code})
+            </li>
+          ))}
+        </ul>
+      </div>
+    </div>
+  )
+}
+
+export default StrategiesPage


### PR DESCRIPTION
## Summary
- fix incorrect timeframe usage in CalculateController
- persist price data with new JPA entity and repository
- schedule daily collection of price data
- expose `/api/strategies` endpoints to return results based on stored prices
- add frontend page to show strategy results
- test new controller and persistence service

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_6863db61939483238957359ef7b579ea