### PR TITLE
Persist strategy results

### DIFF
--- a/back/src/main/java/com/stock/bion/back/calculate/StrategyApiController.java
+++ b/back/src/main/java/com/stock/bion/back/calculate/StrategyApiController.java
@@ -1,85 +1,72 @@
 package com.stock.bion.back.calculate;
 
-import com.stock.bion.back.data.DataService;
-import com.stock.bion.back.data.PricePersistenceService;
-import com.stock.bion.back.data.Price;
+import com.stock.bion.back.data.DataService.TimeFrame;
 import com.stock.bion.back.data.Stock;
+import com.stock.bion.back.calculate.StrategyResultRepository;
+import com.stock.bion.back.calculate.StrategyResultEntity;
+import com.stock.bion.back.calculate.StrategyType;
+import java.time.LocalDate;
+import java.util.List;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-import java.util.ArrayList;
-import java.util.List;
-
 @RestController
 @RequestMapping("/api/strategies")
 public class StrategyApiController {
-    private final PricePersistenceService priceService;
-    private final TrailingStopStrategyService trailingStopStrategyService;
-    private final MomentumIncreasingService momentumIncreasingService;
+    private final StrategyResultRepository resultRepository;
 
-    public StrategyApiController(PricePersistenceService priceService,
-                                 TrailingStopStrategyService trailingStopStrategyService,
-                                 MomentumIncreasingService momentumIncreasingService) {
-        this.priceService = priceService;
-        this.trailingStopStrategyService = trailingStopStrategyService;
-        this.momentumIncreasingService = momentumIncreasingService;
+    public StrategyApiController(StrategyResultRepository resultRepository) {
+        this.resultRepository = resultRepository;
     }
 
     @GetMapping("/trailing-stop/short")
     public ResponseEntity<List<Stock>> trailingStopShort() {
-        return ResponseEntity.ok(applyTrailing(DataService.TimeFrame.SHORT_TERM));
+        return ResponseEntity.ok(fetch(StrategyType.TRAILING_STOP, TimeFrame.SHORT_TERM));
     }
 
     @GetMapping("/trailing-stop/middle")
     public ResponseEntity<List<Stock>> trailingStopMiddle() {
-        return ResponseEntity.ok(applyTrailing(DataService.TimeFrame.MEDIUM_TERM));
+        return ResponseEntity.ok(fetch(StrategyType.TRAILING_STOP, TimeFrame.MEDIUM_TERM));
     }
 
     @GetMapping("/trailing-stop/long")
     public ResponseEntity<List<Stock>> trailingStopLong() {
-        return ResponseEntity.ok(applyTrailing(DataService.TimeFrame.LONG_TERM));
+        return ResponseEntity.ok(fetch(StrategyType.TRAILING_STOP, TimeFrame.LONG_TERM));
     }
 
     @GetMapping("/momentum/short")
     public ResponseEntity<List<Stock>> momentumShort() {
-        return ResponseEntity.ok(applyMomentum(DataService.TimeFrame.SHORT_TERM));
+        return ResponseEntity.ok(fetch(StrategyType.MOMENTUM, TimeFrame.SHORT_TERM));
     }
 
     @GetMapping("/momentum/middle")
     public ResponseEntity<List<Stock>> momentumMiddle() {
-        return ResponseEntity.ok(applyMomentum(DataService.TimeFrame.MEDIUM_TERM));
+        return ResponseEntity.ok(fetch(StrategyType.MOMENTUM, TimeFrame.MEDIUM_TERM));
     }
 
     @GetMapping("/momentum/long")
     public ResponseEntity<List<Stock>> momentumLong() {
-        return ResponseEntity.ok(applyMomentum(DataService.TimeFrame.LONG_TERM));
+        return ResponseEntity.ok(fetch(StrategyType.MOMENTUM, TimeFrame.LONG_TERM));
     }
 
-    private List<Stock> applyTrailing(DataService.TimeFrame timeframe) {
-        List<Stock> stocks = priceService.getStocks();
-        List<Stock> result = new ArrayList<>();
-        for (Stock stock : stocks) {
-            List<Price> prices = priceService.getPrices(stock.getCode(), timeframe);
-            if (prices.size() < 4) continue;
-            if (trailingStopStrategyService.isNonHerdTrendSignal(prices)) {
-                result.add(stock);
-            }
+    private List<Stock> fetch(StrategyType type, TimeFrame tf) {
+        StrategyResultEntity latest =
+                resultRepository.findFirstByStrategyTypeAndTimeFrameOrderByEvaluatedAtDesc(type.name(), tf.name());
+        if (latest == null) {
+            return List.of();
         }
-        return result;
+        LocalDate date = latest.getEvaluatedAt();
+        List<StrategyResultEntity> results =
+                resultRepository.findByStrategyTypeAndTimeFrameAndEvaluatedAt(type.name(), tf.name(), date);
+        return results.stream().map(this::toStock).toList();
     }
 
-    private List<Stock> applyMomentum(DataService.TimeFrame timeframe) {
-        List<Stock> stocks = priceService.getStocks();
-        List<Stock> result = new ArrayList<>();
-        for (Stock stock : stocks) {
-            List<Price> prices = priceService.getPrices(stock.getCode(), timeframe);
-            if (prices.size() < 4) continue;
-            if (momentumIncreasingService.isMomentumIncreasing(prices, 0.01, 0.0)) {
-                result.add(stock);
-            }
-        }
-        return result;
+    private Stock toStock(StrategyResultEntity e) {
+        Stock s = new Stock();
+        s.setCode(e.getCode());
+        s.setName(e.getName());
+        return s;
     }
 }

--- a/back/src/main/java/com/stock/bion/back/calculate/StrategyResultEntity.java
+++ b/back/src/main/java/com/stock/bion/back/calculate/StrategyResultEntity.java
@@ -1,0 +1,22 @@
+package com.stock.bion.back.calculate;
+
+import jakarta.persistence.*;
+import java.time.LocalDate;
+import lombok.Getter;
+import lombok.Setter;
+
+@Entity
+@Table(name = "strategy_results")
+@Getter
+@Setter
+public class StrategyResultEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    private String code;
+    private String name;
+    private String strategyType;
+    private String timeFrame;
+    private LocalDate evaluatedAt;
+    private Double signalValue;
+}

--- a/back/src/main/java/com/stock/bion/back/calculate/StrategyResultRepository.java
+++ b/back/src/main/java/com/stock/bion/back/calculate/StrategyResultRepository.java
@@ -1,0 +1,10 @@
+package com.stock.bion.back.calculate;
+
+import java.time.LocalDate;
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface StrategyResultRepository extends JpaRepository<StrategyResultEntity, Long> {
+    StrategyResultEntity findFirstByStrategyTypeAndTimeFrameOrderByEvaluatedAtDesc(String strategyType, String timeFrame);
+    List<StrategyResultEntity> findByStrategyTypeAndTimeFrameAndEvaluatedAt(String strategyType, String timeFrame, LocalDate evaluatedAt);
+}

--- a/back/src/main/java/com/stock/bion/back/calculate/StrategyResultService.java
+++ b/back/src/main/java/com/stock/bion/back/calculate/StrategyResultService.java
@@ -1,0 +1,55 @@
+package com.stock.bion.back.calculate;
+
+import com.stock.bion.back.data.DataService.TimeFrame;
+import com.stock.bion.back.data.Price;
+import com.stock.bion.back.data.PricePersistenceService;
+import com.stock.bion.back.data.Stock;
+import java.time.LocalDate;
+import java.util.List;
+import org.springframework.stereotype.Service;
+
+@Service
+public class StrategyResultService {
+    private final PricePersistenceService priceService;
+    private final TrailingStopStrategyService trailingStopStrategyService;
+    private final MomentumIncreasingService momentumIncreasingService;
+    private final StrategyResultRepository repository;
+
+    public StrategyResultService(PricePersistenceService priceService,
+                                 TrailingStopStrategyService trailingStopStrategyService,
+                                 MomentumIncreasingService momentumIncreasingService,
+                                 StrategyResultRepository repository) {
+        this.priceService = priceService;
+        this.trailingStopStrategyService = trailingStopStrategyService;
+        this.momentumIncreasingService = momentumIncreasingService;
+        this.repository = repository;
+    }
+
+    public void evaluateDaily() {
+        LocalDate today = LocalDate.now();
+        List<Stock> stocks = priceService.getStocks();
+        for (Stock stock : stocks) {
+            for (TimeFrame tf : TimeFrame.values()) {
+                List<Price> prices = priceService.getPrices(stock.getCode(), tf);
+                if (prices.size() < 4) continue;
+                if (trailingStopStrategyService.isNonHerdTrendSignal(prices)) {
+                    save(stock, StrategyType.TRAILING_STOP, tf, today, 1.0);
+                }
+                if (momentumIncreasingService.isMomentumIncreasing(prices, 0.01, 0.0)) {
+                    save(stock, StrategyType.MOMENTUM, tf, today, 1.0);
+                }
+            }
+        }
+    }
+
+    private void save(Stock stock, StrategyType type, TimeFrame tf, LocalDate date, double value) {
+        StrategyResultEntity e = new StrategyResultEntity();
+        e.setCode(stock.getCode());
+        e.setName(stock.getName());
+        e.setStrategyType(type.name());
+        e.setTimeFrame(tf.name());
+        e.setEvaluatedAt(date);
+        e.setSignalValue(value);
+        repository.save(e);
+    }
+}

--- a/back/src/main/java/com/stock/bion/back/calculate/StrategyType.java
+++ b/back/src/main/java/com/stock/bion/back/calculate/StrategyType.java
@@ -1,0 +1,6 @@
+package com.stock.bion.back.calculate;
+
+public enum StrategyType {
+    TRAILING_STOP,
+    MOMENTUM
+}

--- a/back/src/main/java/com/stock/bion/back/data/PriceScheduler.java
+++ b/back/src/main/java/com/stock/bion/back/data/PriceScheduler.java
@@ -1,18 +1,23 @@
 package com.stock.bion.back.data;
 
+import com.stock.bion.back.calculate.StrategyResultService;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 
 @Component
 public class PriceScheduler {
     private final PricePersistenceService pricePersistenceService;
+    private final StrategyResultService strategyResultService;
 
-    public PriceScheduler(PricePersistenceService pricePersistenceService) {
+    public PriceScheduler(PricePersistenceService pricePersistenceService,
+                         StrategyResultService strategyResultService) {
         this.pricePersistenceService = pricePersistenceService;
+        this.strategyResultService = strategyResultService;
     }
 
     @Scheduled(cron = "0 0 1 * * *")
     public void collectDailyPrices() {
         pricePersistenceService.fetchAndSavePricesForAllCompanies();
+        strategyResultService.evaluateDaily();
     }
 }

--- a/back/src/test/java/com/stock/bion/back/calculate/StrategyApiControllerTest.java
+++ b/back/src/test/java/com/stock/bion/back/calculate/StrategyApiControllerTest.java
@@ -1,7 +1,7 @@
 package com.stock.bion.back.calculate;
 
-import com.stock.bion.back.data.PriceEntity;
-import com.stock.bion.back.data.PriceRepository;
+import com.stock.bion.back.calculate.StrategyResultEntity;
+import com.stock.bion.back.calculate.StrategyResultRepository;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -21,35 +21,23 @@ class StrategyApiControllerTest {
     @Autowired
     MockMvc mockMvc;
     @Autowired
-    PriceRepository priceRepository;
+    StrategyResultRepository resultRepository;
 
     @BeforeEach
     void setup() {
-        priceRepository.deleteAll();
+        resultRepository.deleteAll();
         insertSample("AAA", "AAA Corp");
     }
 
     private void insertSample(String code, String name) {
-        LocalDate today = LocalDate.now();
-        priceRepository.save(make(code, name, today, 110, 1000));
-        priceRepository.save(make(code, name, today.minusDays(1), 105, 800));
-        priceRepository.save(make(code, name, today.minusDays(2), 100, 900));
-        priceRepository.save(make(code, name, today.minusDays(3), 95, 1100));
-        priceRepository.save(make(code, name, today.minusDays(4), 90, 1200));
-    }
-
-    private PriceEntity make(String code, String name, LocalDate date, double close, double volume) {
-        PriceEntity e = new PriceEntity();
+        StrategyResultEntity e = new StrategyResultEntity();
         e.setCode(code);
         e.setName(name);
-        e.setDate(date);
-        e.setClose(close);
-        e.setHigh(close);
-        e.setLow(close - 10);
-        e.setOpen(close - 5);
-        e.setVolume(volume);
-        e.setDiff(0);
-        return e;
+        e.setStrategyType("TRAILING_STOP");
+        e.setTimeFrame("SHORT_TERM");
+        e.setEvaluatedAt(LocalDate.now());
+        e.setSignalValue(1.0);
+        resultRepository.save(e);
     }
 
     @Test


### PR DESCRIPTION
## Summary
- define `StrategyResultEntity` and related repository/service
- compute strategy results daily from saved prices
- read strategy results in `StrategyApiController`
- update scheduler to store results
- adjust controller test

## Testing
- `./gradlew spotlessApply` *(fails: Unable to tunnel through proxy)*
- `./gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_6865112ddabc8323b858dc9dc02ab2a2