### PR TITLE
Fix tests for strategy service and controller

### DIFF
--- a/back/src/test/java/com/stock/bion/back/calculate/StrategyApiControllerTest.java
+++ b/back/src/test/java/com/stock/bion/back/calculate/StrategyApiControllerTest.java
@@ -9,6 +9,7 @@ import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMock
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.security.test.context.support.WithMockUser;
 
 import java.time.LocalDate;
 
@@ -41,6 +42,7 @@ class StrategyApiControllerTest {
     }
 
     @Test
+    @WithMockUser
     void trailingStopShort_returnsData() throws Exception {
         mockMvc.perform(get("/api/strategies/trailing-stop/short").accept(MediaType.APPLICATION_JSON))
                 .andExpect(status().isOk())

--- a/back/src/test/java/com/stock/bion/back/calculate/TrailingStopStrategyServiceTest.java
+++ b/back/src/test/java/com/stock/bion/back/calculate/TrailingStopStrategyServiceTest.java
@@ -47,11 +47,10 @@ class TrailingStopStrategyServiceTest {
 		return p;
 	}
 
-	private void stubPrices(List<Price> prices) {
-		when(dataService.getPriceInfo(eq("TEST"), anyInt()))
-				.thenReturn(prices)      // page = 1
-				.thenReturn(List.of());  // page ≥ 2 → 루프 종료
-	}
+        private void stubPrices(List<Price> prices) {
+                when(dataService.fetchPricesForTimeframe(eq("TEST"), any()))
+                                .thenReturn(prices);
+        }
 
 	/** 시그널이 true 여야 하는 경우 */
 	@Test
@@ -77,12 +76,15 @@ class TrailingStopStrategyServiceTest {
 		assertFalse(service.isNonHerdTrendSignal("TEST", DataService.TimeFrame.SHORT_TERM));
 	}
 
-	@Test
-    void testIsNonHerdTrendSignal_viaServiceFetch() {
-        when(dataService.getPriceInfo("TEST", 1)).thenReturn(samplePrices);
-        boolean result = service.isNonHerdTrendSignal("TEST",
-				DataService.TimeFrame.SHORT_TERM);
-        assertTrue(result);
-        verify(dataService, atLeastOnce()).getPriceInfo("TEST", 1);
-    }
+        @Test
+        void testIsNonHerdTrendSignal_viaServiceFetch() {
+                when(dataService.fetchPricesForTimeframe("TEST", DataService.TimeFrame.SHORT_TERM))
+                                .thenReturn(samplePrices);
+
+                boolean result = service.isNonHerdTrendSignal("TEST", DataService.TimeFrame.SHORT_TERM);
+
+                assertTrue(result);
+                verify(dataService, atLeastOnce())
+                                .fetchPricesForTimeframe("TEST", DataService.TimeFrame.SHORT_TERM);
+        }
 }


### PR DESCRIPTION
## Summary
- enable mock security for `StrategyApiControllerTest`
- stub `fetchPricesForTimeframe` in `TrailingStopStrategyServiceTest`

## Testing
- `./gradlew test` *(fails: unable to download Gradle wrapper due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_6866296bdb608323b53c7447f9dbc483