### PR TITLE
Add axios auth logic

### DIFF
--- a/front/package.json
+++ b/front/package.json
@@ -12,7 +12,8 @@
   "dependencies": {
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
-    "react-router-dom": "^6.23.1"
+    "react-router-dom": "^6.23.1",
+    "axios": "^1.6.8"
   },
   "devDependencies": {
     "@eslint/js": "^9.29.0",

--- a/front/src/LoginForm.tsx
+++ b/front/src/LoginForm.tsx
@@ -1,5 +1,6 @@
 import { type FormEvent, useState } from 'react'
 import { useNavigate } from 'react-router-dom'
+import api from './api'
 
 function LoginForm() {
   const navigate = useNavigate()
@@ -10,29 +11,23 @@ function LoginForm() {
   const handleSubmit = async (e: FormEvent) => {
     e.preventDefault()
     try {
-      const res = await fetch(`${import.meta.env.VITE_API_BASE_URL || ''}/api/auth/login`, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ username, password }),
-      })
+      const res = await api.post('/api/auth/login', { username, password })
 
-      if (res.ok) {
-        const data = await res.json()
-        if (data && typeof data.token === 'string') {
-          localStorage.setItem('token', data.token)
-          setUsername('')
-          setPassword('')
-          navigate('/')
-        } else {
-          setMessage('Invalid response from server')
-        }
-      } else if (res.status === 401) {
+      const data = res.data as any
+      if (data && typeof data.token === 'string') {
+        localStorage.setItem('token', data.token)
+        setUsername('')
+        setPassword('')
+        navigate('/')
+      } else {
+        setMessage('Invalid response from server')
+      }
+    } catch (err: any) {
+      if (err.response?.status === 401) {
         setMessage('Invalid credentials')
       } else {
         setMessage('Login failed')
       }
-    } catch {
-      setMessage('Network error: unable to connect')
     }
   }
 

--- a/front/src/RegisterForm.tsx
+++ b/front/src/RegisterForm.tsx
@@ -1,5 +1,6 @@
 import { type FormEvent, useState } from 'react'
 import { useNavigate } from 'react-router-dom'
+import api from './api'
 
 function RegisterForm() {
   const navigate = useNavigate()
@@ -21,33 +22,25 @@ function RegisterForm() {
       return
     }
     try {
-      const res = await fetch(`${import.meta.env.VITE_API_BASE_URL || ''}/api/users/register`, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ username, password, confirmPassword, email, phone }),
+      await api.post('/api/users/register', {
+        username,
+        password,
+        confirmPassword,
+        email,
+        phone
       })
-
-      if (res.ok) {
-        setUsername('')
-        setPassword('')
-        setConfirmPassword('')
-        setEmail('')
-        setPhone('')
-        navigate('/login')
-      } else {
-        let errorMsg = 'Registration failed'
-        try {
-          const data = await res.json()
-          if (data && typeof data.message === 'string') {
-            errorMsg = data.message
-          }
-        } catch {
-          // ignore JSON parsing errors
-        }
-        setMessage(errorMsg)
+      setUsername('')
+      setPassword('')
+      setConfirmPassword('')
+      setEmail('')
+      setPhone('')
+      navigate('/login')
+    } catch (err: any) {
+      let errorMsg = 'Registration failed'
+      if (err.response?.data && typeof err.response.data.message === 'string') {
+        errorMsg = err.response.data.message
       }
-    } catch {
-      setMessage('Network error: unable to connect')
+      setMessage(errorMsg)
     }
   }
 

--- a/front/src/api.ts
+++ b/front/src/api.ts
@@ -1,0 +1,21 @@
+import axios from 'axios'
+
+const api = axios.create({
+  baseURL: import.meta.env.VITE_API_BASE_URL || ''
+})
+
+api.interceptors.request.use((config) => {
+  if (config.url && (config.url.includes('/api/auth/login') || config.url.includes('/api/users/register'))) {
+    return config
+  }
+  const token = localStorage.getItem('token')
+  if (token) {
+    config.headers = {
+      ...config.headers,
+      Authorization: `Bearer ${token}`
+    }
+  }
+  return config
+})
+
+export default api

--- a/front/src/pages/StrategiesPage.tsx
+++ b/front/src/pages/StrategiesPage.tsx
@@ -1,18 +1,19 @@
 import { useEffect, useState } from 'react'
+import api from '../api'
 
 function StrategiesPage() {
   const [trailing, setTrailing] = useState<any[]>([])
   const [momentum, setMomentum] = useState<any[]>([])
 
   useEffect(() => {
-    fetch(`${import.meta.env.VITE_API_BASE_URL || ''}/api/strategies/trailing-stop/short`)
-      .then((res) => res.json())
-      .then(setTrailing)
+    api
+      .get('/api/strategies/trailing-stop/short')
+      .then((res) => setTrailing(res.data))
       .catch(() => {})
 
-    fetch(`${import.meta.env.VITE_API_BASE_URL || ''}/api/strategies/momentum/short`)
-      .then((res) => res.json())
-      .then(setMomentum)
+    api
+      .get('/api/strategies/momentum/short')
+      .then((res) => setMomentum(res.data))
       .catch(() => {})
   }, [])
 


### PR DESCRIPTION
## Summary
- add axios auth interceptor in `front/src/api.ts`
- switch network calls to axios
- keep login and register without auth header
- add axios to dependencies

## Testing
- `npm run lint` *(fails: Cannot find package)*
- `./gradlew test` *(fails: unable to download dependencies)*


------
https://chatgpt.com/codex/tasks/task_e_68663db77b50832391f890f85bd3dcda